### PR TITLE
update consul base_url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-default['consul']['base_url']       = "https://dl.bintray.com/mitchellh/consul/%{version}.zip"
+default['consul']['base_url']       = "https://releases.hashicorp.com/consul/%{version}/consul_%{version}_linux_amd64.zip"
 default['consul']['version']        = '0.5.1'
 default['consul']['install_method'] = 'binary'
 default['consul']['install_dir']    = '/usr/local/bin'


### PR DESCRIPTION
ダウンロードできなくなっていたので`base_url`をアップデート。

いままで

```
curl -I https://dl.bintray.com/mitchellh/consul/0.5.1.zip
HTTP/1.1 404 Not Found
Server: nginx
Date: Mon, 22 Feb 2016 08:45:33 GMT
Content-Type: application/octet-stream
Content-Length: 0
Connection: keep-alive
```

修正後

```
curl -I https://releases.hashicorp.com/consul/0.5.1/consul_0.5.1_linux_amd64.zip
HTTP/1.1 200 OK
Last-Modified: Mon, 02 Nov 2015 14:13:35 GMT
Content-Type: application/zip
Via: 1.1 varnish
Fastly-Debug-Digest: dbb501d3ac77d4c70c4fa4d361df1ae2cd32727aff8c86416d41803939377b6f
Content-Length: 4802625
Accept-Ranges: bytes
Date: Mon, 22 Feb 2016 08:45:05 GMT
Via: 1.1 varnish
Age: 376
Connection: keep-alive
X-Served-By: cache-iad2140-IAD, cache-nrt6129-NRT
X-Cache: HIT, HIT
X-Cache-Hits: 1, 1
```
